### PR TITLE
changed QtWebKitWidgets/QWebView to PyQt4.QtWebKit

### DIFF
--- a/resource_sharing/gui/ui/resource_sharing_dialog_base.ui
+++ b/resource_sharing/gui/ui/resource_sharing_dialog_base.ui
@@ -595,7 +595,7 @@
   <customwidget>
    <class>QWebView</class>
    <extends>QWidget</extends>
-   <header>QtWebKitWidgets/QWebView</header>
+   <header>PyQt4.QtWebKit</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
hi @akbargumbira, did it work for you with QtWebKitWidgets/QWebView? you did a promoted QWidget right? for me it breaks saying:

This plugin is broken
No module named QtWebKitWidgets.QWebView