### PR TITLE
Allow the user to define the location of the collections in the file system

### DIFF
--- a/resource_sharing/utilities.py
+++ b/resource_sharing/utilities.py
@@ -82,6 +82,12 @@ def local_collection_root_dir_key():
     return 'localCollectionDir'
 
 
+def default_local_collection_root_dir():
+    return os.path.join(QgsApplication.qgisSettingsDirPath(),
+                        'resource_sharing',
+                        'collections')
+
+
 def local_collection_path(id=None):
     """Get the path to the local collection dir.
 

--- a/resource_sharing/utilities.py
+++ b/resource_sharing/utilities.py
@@ -6,7 +6,7 @@ import logging
 
 import ntpath
 
-from qgis.PyQt.QtCore import QDir
+from qgis.PyQt.QtCore import QDir, QSettings
 try:
     from qgis.core import QgsApplication, QGis as Qgis
 except ImportError:

--- a/resource_sharing/utilities.py
+++ b/resource_sharing/utilities.py
@@ -96,9 +96,16 @@ def local_collection_path(id=None):
     settings = QSettings()
     settings.beginGroup(resource_sharing_group())
     if settings.contains(local_collection_root_dir_key()):
+        # The path is defined in the settings - use it
         path = settings.value(local_collection_root_dir_key())   
     else:
-        path = default_local_collection_root_dir()
+        # The path is not defined in the settings
+        if os.path.exists(old_local_collection_path()):
+            # The pre-version 0.10 directory exists - so use it
+            path = old_local_collection_path()
+        else:
+            # Use the new default directory
+            path = default_local_collection_root_dir()
         LOGGER.info('Setting the collection path to ' + path)
         settings.setValue(local_collection_root_dir_key(),
                           path)

--- a/resource_sharing/utilities.py
+++ b/resource_sharing/utilities.py
@@ -2,6 +2,7 @@
 import os
 # Use pathlib instead of os.path?
 # from pathlib import Path
+import logging
 
 import ntpath
 
@@ -13,6 +14,8 @@ except ImportError:
 
 from resource_sharing import config
 import jinja2
+
+LOGGER = logging.getLogger('QGIS Resources Sharing')
 
 
 def resources_path(*args):
@@ -94,6 +97,11 @@ def local_collection_path(id=None):
         settings.setValue(local_collection_root_dir_key(),
                           path)
     settings.endGroup()
+    # If the directory does not exist, create it!
+    if not os.path.exists(path):
+            LOGGER.debug('coll_mgr - creating local collection dir: ' +
+                         str(path))
+            os.makedirs(path)
 
     # # path = Path(QDir.homePath()) / 'QGIS' / 'Resource Sharing')
     # path = os.path.join(

--- a/resource_sharing/utilities.py
+++ b/resource_sharing/utilities.py
@@ -70,7 +70,8 @@ def resource_sharing_group():
 
 def repositories_cache_path():
     """Get the path to the repositories cache."""
-    # return Path(QgsApplication.qgisSettingsDirPath()) / 'resource_sharing' / 'repositories_cache'
+    # return Path(QgsApplication.qgisSettingsDirPath()) /
+    #             'resource_sharing' / 'repositories_cache'
     return os.path.join(
         QgsApplication.qgisSettingsDirPath(),
         'resource_sharing',
@@ -97,7 +98,7 @@ def local_collection_path(id=None):
     settings.beginGroup(resource_sharing_group())
     if settings.contains(local_collection_root_dir_key()):
         # The path is defined in the settings - use it
-        path = settings.value(local_collection_root_dir_key())   
+        path = settings.value(local_collection_root_dir_key())
     else:
         # The path is not defined in the settings
         if os.path.exists(old_local_collection_path()):

--- a/resource_sharing/utilities.py
+++ b/resource_sharing/utilities.py
@@ -60,6 +60,11 @@ def repo_settings_group():
     return '/ResourceSharing/repository'
 
 
+def resource_sharing_group():
+    """Get the settings group for the local collection directorys."""
+    return '/ResourceSharing'
+
+
 def repositories_cache_path():
     """Get the path to the repositories cache."""
     # return Path(QgsApplication.qgisSettingsDirPath()) / 'resource_sharing' / 'repositories_cache'
@@ -69,20 +74,52 @@ def repositories_cache_path():
         'repositories_cache')
 
 
+def local_collection_root_dir_key():
+    """The QSettings key for the local collections root dir."""
+    return 'localCollectionDir'
+
+
 def local_collection_path(id=None):
     """Get the path to the local collection dir.
 
     If id is not passed, it will just return the root dir of the collections.
     """
-    # path = Path(QDir.homePath()) / 'QGIS' / 'Resource Sharing')
+    settings = QSettings()
+    settings.beginGroup(resource_sharing_group())
+    if settings.contains(local_collection_root_dir_key()):
+        path = settings.value(local_collection_root_dir_key())   
+    else:
+        path = default_local_collection_root_dir()
+        LOGGER.info('Setting the collection path to ' + path)
+        settings.setValue(local_collection_root_dir_key(),
+                          path)
+    settings.endGroup()
+
+    # # path = Path(QDir.homePath()) / 'QGIS' / 'Resource Sharing')
+    # path = os.path.join(
+    #     QDir.toNativeSeparators(QDir.homePath()),
+    #     'QGIS',
+    #     'Resource Sharing')
+    if id:
+        collection_name = config.COLLECTIONS[id]['name']
+        dir_name = '%s (%s)' % (collection_name, id)
+        # path = path / dir_name
+        path = os.path.join(path, dir_name)
+    return path
+
+
+def old_local_collection_path(id=None):
+    """Get the path to the old local collection dir.
+    (in case we would like to help the users migrate)
+    If id is not passed, it will just return the root dir of the collections.
+    """
     path = os.path.join(
-        QDir.toNativeSeparators(QDir.homePath()),
+        QDir.homePath(),
         'QGIS',
         'Resource Sharing')
     if id:
         collection_name = config.COLLECTIONS[id]['name']
         dir_name = '%s (%s)' % (collection_name, id)
-        # path = path / dir_name
         path = os.path.join(path, dir_name)
     return path
 


### PR DESCRIPTION
Adds a setting ('localCollectionDir') under [ResourceSharing] to ``QGIS.ini`` that contains the file system location of the root directory of the collections. This allows users to change the file system location of the collections (as requested in #51).

Also, the new default location is "collections" under the ``resource_sharing`` directory in the user's QGIS directory (hidden - on Ubuntu:
``~/.local/share/QGIS/QGIS3/profiles/default/resource_sharing/collections``,
on Windows:
``C:\Users\<USER>\AppData\Roaming\QGIS\QGIS3\profiles\default\resource_sharing\collections``
-- alongside the "resources" directory and the repository cache).

To avoid problems for existing installations:
0. The default is to set 'localCollectionDir' to the new default location, but there are exceptions...
1. The plugin checks if 'localCollectionDir' is set. If it is, that location is used, if not, it continues
   to the next step...
2. 'localCollectionDir' is not set (not first run of the plugin), so it checks if the new default location
     is on the file system. If it is there, that indicates that the user prefers the new default location,
     so that is stored in 'localCollectionDir', and used). If not, it continues to the next step...
3. The new default location does not exist in the file system, so it checks if the old location
   (``~/QGIS/Resource Sharing``) exists in the file system, indicating that this is not a new user of
   the plugin. We don't want to be intrusive, so we let the user continue to use that location.
   (so it is stored in 'localCollectionDir', and used). If not, it continues to the next step...
4. The old location is not there, so the new default location is stored in 'localCollectionDir',
    and used.

By doing it like this, users who have used the plugin before will keep the old location for their collections (by default). If they would like to use another location, they will have to set it up later.


Addresses issues raised in #51, as it allows users to change the location of this directory by
modifying their QGIS3.ini file.
If the directory does not exist, it will be created (probably addressing #43).

Changing this setting will not cause installed collections to be moved.

Fixes: #51
Fixes: #43