### PR TITLE
Use correct name (uppercase in "sharing") for logger

### DIFF
--- a/resource_sharing/custom_logging.py
+++ b/resource_sharing/custom_logging.py
@@ -3,7 +3,7 @@ import logging
 
 from qgis.core import QgsMessageLog, Qgis
 
-LOGGERNAME = 'QGIS Resource sharing'
+LOGGERNAME = 'QGIS Resource Sharing'
 
 
 def setup_logger():


### PR DESCRIPTION
The logger name needs to be consistent for the logging to work.