### PR TITLE
Simple fix to avoid ResourceWarning

### DIFF
--- a/resource_sharing/repository_handler/remote_git_handler.py
+++ b/resource_sharing/repository_handler/remote_git_handler.py
@@ -91,7 +91,7 @@ class RemoteGitHandler(BaseRepositoryHandler):
         :return: (success (True or False), error message (None if success))
         :rtype: (boolean, string)
         """
-        # Hack to avoid irritating dulwich / porcelain ResourceWarning
+        # Hack to avoid irritating Dulwich / Porcelain ResourceWarning
         warnings.filterwarnings("ignore", category=ResourceWarning)
          # Clone or pull the repositories first
         local_repo_dir = os.path.join(

--- a/resource_sharing/repository_handler/remote_git_handler.py
+++ b/resource_sharing/repository_handler/remote_git_handler.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import logging
 import traceback
+import warnings
 
 from qgis.core import QgsApplication
 
@@ -90,7 +91,9 @@ class RemoteGitHandler(BaseRepositoryHandler):
         :return: (success (True or False), error message (None if success))
         :rtype: (boolean, string)
         """
-        # Clone or pull the repositories first
+        # Hack to avoid irritating dulwich / porcelain ResourceWarning
+        warnings.filterwarnings("ignore", category=ResourceWarning)
+         # Clone or pull the repositories first
         local_repo_dir = os.path.join(
             QgsApplication.qgisSettingsDirPath(),
             'resource_sharing',


### PR DESCRIPTION
A hack (using `warnings.filterwarnings`) to avoid `ResourceWarning` when using *dulwich* / *Porcelain* to download github repositories.
Fix #95.