### PR TITLE
Manual file/directory removal before pull

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -18,6 +18,7 @@ deprecated=False
 icon=resources/icon.png
 changelog=
         0.13.0 - GUI updates (#100)
+               - Files removed from repository are still being installed from cache (#44)
                - Provide installation summary (#6)
                - Avoid (parent) tag with no members in QGIS 3 style documents (#101)
                - Fix reloading problems ([WinError 5]) with Microsoft Windows (#103)

--- a/resource_sharing/repository_handler/remote_git_handler.py
+++ b/resource_sharing/repository_handler/remote_git_handler.py
@@ -112,7 +112,7 @@ class RemoteGitHandler(BaseRepositoryHandler):
                     self.url, local_repo_dir,
                     errstream=writeOut
                 )
-                repo.close()  # To avoid WinErr 32
+                repo.close()  # Try to avoid WinErr 32
             except Exception as e:
                 # Try to clone with https if it is a ssh url
                 git_parsed = parse(self.url)
@@ -121,7 +121,7 @@ class RemoteGitHandler(BaseRepositoryHandler):
                         repo = porcelain.clone(
                             git_parsed.url2https, local_repo_dir,
                             errstream=writeOut)
-                        repo.close()  # To avoid WinErr 32
+                        repo.close()  # Try to avoid WinErr 32
                     except Exception as e:
                         error_message = 'Error: %s' % str(e)
                         LOGGER.exception(traceback.format_exc())
@@ -136,6 +136,9 @@ class RemoteGitHandler(BaseRepositoryHandler):
                                  'collection failed.')
                 return False, error_message
         else:
+            # Hack until dulwich/porcelain handles file removal
+            collDir = os.path.join(local_repo_dir, 'collections')
+            shutil.rmtree(collDir)
             try:
                 porcelain.pull(
                     local_repo_dir,


### PR DESCRIPTION
Dulwich/porcelain does not handle file removal (https://github.com/dulwich/dulwich/issues/452, https://github.com/dulwich/dulwich/issues/588). To ensure that the collection directory of remote repository is mirrored locally when a collection is reinstalled, the collection directory is removed before pulling.
Fixes #44.