### PR TITLE
docs: use new GitHub Pages workflow instead of gh-pages branch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,8 @@ name: "📚 Documentation"
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
     paths:
       - ".github/workflows/documentation.yml"
       - "docs/*/**"
@@ -12,8 +13,29 @@ on:
     tags:
       - "*"
 
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/documentation.yml"
+      - docs/**/*
+      - requirements/documentation.txt
+
+  workflow_dispatch:
+
+# Allow one concurrent deployment per branch/pr
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   PYTHON_VERSION: 3.9
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   build:
@@ -26,9 +48,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
           cache-dependency-path: "requirements/documentation.txt"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: |
@@ -38,7 +60,25 @@ jobs:
       - name: Build doc using Sphinx
         run: sphinx-build -b html -d docs/_build/cache -j auto docs docs/_build/html
 
+      - name: Save build doc as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation
+          path: docs/_build/html/*
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
+        with:
+          path: docs/_build/html/
+
       - name: Deploy to GitHub Pages
-        run: |
-          python -m pip install -U ghp-import
-          ghp-import --force --no-history --no-jekyll --push docs/_build/html
+        id: deployment
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
+        uses: actions/deploy-pages@v4

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -2,7 +2,6 @@
 # ------------------------
 
 furo>=2023.*
-ghp-import>2.0,<2.2
 myst-parser[linkify]>=2
 sphinx-autobuild>=2021.*
 sphinx-copybutton>=0.3,<1


### PR DESCRIPTION
In this PR :

- rely on modern GitHub Pages deployment through GitHub Actions instead of pushing to a specific branch (gh-pages). A cleaner behavior, similar to GitLab Pages.
- improve documentation workflow to build also on PR but not deploy
- remove ghp-import dependency since it's not necessary anymore

After merging this one, remember to remove gh-pages branch and switch to beta GitHub Actions in https://github.com/QGIS-Contribution/QGIS-ResourceSharing/settings/pages

![image](https://github.com/QGIS-Contribution/QGIS-ResourceSharing/assets/1596222/ea8184fa-40f9-430b-9121-1e0bbc1043b1)
