### PR TITLE
update(ci): use Python 3.12 to fit QGIS shipped version

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -2,16 +2,18 @@ name: "📦 Build & 🚀 Release"
 
 env:
   PROJECT_FOLDER: "qgis_resource_sharing"
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: "3.12"
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
     tags:
       - "*"
 
   pull_request:
-    branches: [master]
+    branches:
+      - master
     paths:
       - .github/workflows/build_release.yml
 
@@ -88,7 +90,9 @@ jobs:
   packaging:
     name: "📦 Packaging plugin"
     runs-on: ubuntu-latest
-    needs: [translation, dependencies]
+    needs:
+      - dependencies
+      - translation
 
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
@@ -145,7 +149,9 @@ jobs:
   release:
     name: "🚀 Release"
     runs-on: ubuntu-latest
-    needs: [translation, dependencies]
+    needs:
+      - dependencies
+      - translation
 
     if: startsWith(github.ref, 'refs/tags/')
 

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          # commented out waiting for Python 3.12 being available for pyqt5-tools. See: https://github.com/altendky/pyqt-tools/issues/131
+          # python-version: ${{ env.PYTHON_VERSION }}
+          python-version: "3.11"
           cache: "pip"
           cache-dependency-path: "requirements/translation.txt"
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,7 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: "3.12"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,18 +2,20 @@ name: "✅ Linter"
 
 env:
   PROJECT_FOLDER: "qgis_resource_sharing"
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: "3.12"
 
 # because linter is a required check, it must be triggered on every push and not filtered on paths
 on:
   push:
-    branches: [master]
+    branches:
+      - master
     paths:
       - "**.py"
       - .github/workflows/linter.yml
 
   pull_request:
-    branches: [master]
+    branches:
+      - master
     paths:
       - "**.py"
       - .github/workflows/linter.yml

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -2,7 +2,8 @@ name: "🎳 Tester"
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
     paths:
       - "**.py"
       - .github/workflows/tester.yml
@@ -10,7 +11,8 @@ on:
       - requirements/testing.txt
 
   pull_request:
-    branches: [master]
+    branches:
+      - master
     paths:
       - "**.py"
       - .github/workflows/tester.yml
@@ -19,7 +21,7 @@ on:
 
 env:
   PROJECT_FOLDER: "qgis_resource_sharing"
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: "3.12"
 
 jobs:
   tests-unit:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,8 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-added-large-files
-        args: ["--maxkb=500"]
+        args:
+          - --maxkb=500
       - id: check-case-conflict
       - id: check-xml
       - id: check-yaml
@@ -13,40 +14,51 @@ repos:
       - id: end-of-file-fixer
       - id: fix-byte-order-marker
       - id: fix-encoding-pragma
-        args: [--remove]
+        args:
+          - --remove
       - id: trailing-whitespace
-        args: [--markdown-linebreak-ext=md]
+        args:
+          - --markdown-linebreak-ext=md
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:
       - id: remove-tabs
-        args: ["--whitespaces-count", "4"]
+        args:
+          - --whitespaces-count
+          - "4"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.8.1"
     hooks:
       - id: ruff
-        args: ["--fix-only", "--target-version=py39"]
+        args:
+          - --fix-only
+          - --target-version=py312
 
   - repo: https://github.com/psf/black
     rev: 24.10.0
     hooks:
       - id: black
-        args: ["--target-version=py39"]
+        args:
+          - --target-version=py312
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
       - id: isort
-        args: ["--profile", "black", "--filter-files"]
+        args:
+          - --profile
+          - black
+          - --filter-files
 
   - repo: https://github.com/pycqa/flake8
     rev: 7.1.1
     hooks:
       - id: flake8
         files: ^qgis_resource_sharing/.*\.py$
-        additional_dependencies: ["flake8-qgis<2"]
+        additional_dependencies:
+          - "flake8-qgis"
         args:
           [
             "--config=setup.cfg",


### PR DESCRIPTION
Since QGIS changed his shipped Python version from 3.9 to 3.12 without any warning and in the middle of a LTR cycle (between 3.34.5 and 3.34.6) and giving that plugin embeds some external dependency ([dulwich](https://github.com/jelmer/dulwich)), we have to align Python version with the used in QGIS.

Note: I've to use Python 3.11 for the translation job only since pyqt5-tools is still not compatible with upper versions (see https://github.com/altendky/pyqt-tools/issues/132).