### PR TITLE
update(ci): rm reference to set-output

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -150,10 +150,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-      - name: Get tag name as version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/