### PR TITLE
update(packaging): bump minimal QGIS version to 3.34.6

### DIFF
--- a/qgis_resource_sharing/metadata.txt
+++ b/qgis_resource_sharing/metadata.txt
@@ -14,9 +14,9 @@ repository=https://github.com/QGIS-Contribution/QGIS-ResourceSharing/
 tracker=https://github.com/QGIS-Contribution/QGIS-ResourceSharing/issues/
 
 # versioning
-version=1.1.1
-qgisMinimumVersion=3.22
-qgisMaximumVersion=3.34.5
+version=1.2.0
+qgisMinimumVersion=3.34.6
+qgisMaximumVersion=3.99
 experimental=False
 deprecated=False
 changelog=


### PR DESCRIPTION
Needed because of rough change of shipped Python version in QGIS LTR for Windows... :man_facepalming: 